### PR TITLE
chore: add working directory input to node-setup

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,6 +1,12 @@
 name: Node Setup
 description: Read .nvmrc, nvm use, cache and install
 
+inputs:
+  working-directory:
+    description: The current working directory to setup node into
+    required: false
+    default: '.'
+
 runs:
   using: 'composite'
 
@@ -14,6 +20,7 @@ runs:
       id: yarn-cache-dir-path
       shell: bash
       run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Cache Root Dependencies
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -26,4 +33,5 @@ runs:
 
     - name: Install Dependencies
       shell: bash
-      run: yarn install --immutable
+      run: yarn install --immutable --check-files
+      working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
I haven't yet put the finger on the documentation officially stating that delegating steps to a custom action do not use the `working-directory` setting defined in the "caller" workflow. In this instance, a project using this action in one of its workflows was setting a default working directory, which was a sub-directory of a git repository. Then, this action was installing the dependencies, but in the repository root, which was sort of unexpected to the client workflow.

The only directly relevant forum thread I found is below.

See: [Sort of related StackOverflow thread](https://stackoverflow.com/questions/58139175/running-actions-in-another-directory)